### PR TITLE
feat: use lame uri model for opensea

### DIFF
--- a/contracts/contracts/MarzResources.sol
+++ b/contracts/contracts/MarzResources.sol
@@ -45,6 +45,10 @@ contract MarzResources is ERC1155Upgradeable {
     mapping(uint256 => uint256) public startTimes;
     mapping(uint256 => uint256) public claimed;
 
+    string public constant baseURI = "https://api.marzmining.xyz/token/";
+
+    string public name;
+    string public symbol;
     address public marz;
 
     //--------------------------------------------------------------------------
@@ -58,6 +62,8 @@ contract MarzResources is ERC1155Upgradeable {
         UNCOMMON = [ICE, LEAD, BISMUTH, ANTIMONY, LITHIUM, COBALT];
         RARE = [SILVER, GOLD, CHROMIUM, MERCURY, TUNGSTEN];
         INSANE = [BACTERIA, DIAMOND];
+        name = "Marz Resources";
+        symbol = "rMARZ";
     }
 
     /**
@@ -67,13 +73,13 @@ contract MarzResources is ERC1155Upgradeable {
     function getResources(uint256 plotId) public view returns (uint256[] memory resources) {
         uint256 countRand = random(string(abi.encodePacked("COUNT", plotId.toString())));
         uint256 countScore = countRand % 21;
-        uint256 resourceCount = countScore < 12 ? 1 : countScore < 18 ? 2 : countScore < 20 ? 3 : 4; 
+        uint256 resourceCount = countScore < 12 ? 1 : countScore < 18 ? 2 : countScore < 20 ? 3 : 4;
 
         resources = new uint256[](resourceCount);
         for (uint256 i = 0; i < resourceCount; i++) {
             uint256 rarityRand = random(string(abi.encodePacked("RARITY", i, plotId.toString())));
             uint256 rarity = rarityRand % 101;
-    
+
             // ~1% chance you have this
             if (rarity == 100) {
                 resources[i] = INSANE[rarityRand % INSANE.length];
@@ -81,7 +87,7 @@ contract MarzResources is ERC1155Upgradeable {
             //  ~5% chance you have this
             else if (rarity > 95) {
                 resources[i] = RARE[rarityRand % RARE.length];
-            } 
+            }
             // ~15% chance you have this
             else if (rarity > 80) {
                 resources[i] = UNCOMMON[rarityRand % UNCOMMON.length];
@@ -136,6 +142,10 @@ contract MarzResources is ERC1155Upgradeable {
             }
             _mintBatch(owner, resources, amounts, "");
         }
+    }
+
+    function uri(uint256 tokenId) public view override returns (string memory) {
+        return string(abi.encodePacked(baseURI, tokenId.toString()));
     }
 
     function random(string memory input) internal pure returns (uint256) {

--- a/contracts/tasks/deployers/resources.ts
+++ b/contracts/tasks/deployers/resources.ts
@@ -1,24 +1,21 @@
 import { task, types } from 'hardhat/config'
 import { TaskArguments } from 'hardhat/types'
 
-task('deploy:Resources')
-  .setAction(async function (_args: TaskArguments, hre) {
-    const marz = '0xd0ba8b19b0f5e25c11ed233302e75794c9d3142b';
-    console.log(
-      `Deploying Marz Resources with: \marz ${marz}`,
-    )
+task('deploy:Resources').setAction(async function (_args: TaskArguments, hre) {
+  const marz = '0xd0ba8b19b0f5e25c11ed233302e75794c9d3142b'
+  console.log(`Deploying Marz Resources with: marz ${marz}`)
 
-    const factory = await hre.ethers.getContractFactory('MarzResources')
-    const resources = await hre.upgrades.deployProxy(factory, [marz], {
-      initializer: 'initialize(address)',
-    })
-
-    try {
-      await hre.run('verify:Resources', { address: resources.address })
-    } catch (e) {
-      console.log('Unable to verify on etherscan', e)
-    }
+  const factory = await hre.ethers.getContractFactory('MarzResources')
+  const resources = await hre.upgrades.deployProxy(factory, [marz], {
+    initializer: 'initialize(address)',
   })
+
+  try {
+    await hre.run('verify:Resources', { address: resources.address })
+  } catch (e) {
+    console.log('Unable to verify on etherscan', e)
+  }
+})
 
 task('verify:Resources', 'Verifies on etherscan')
   .addParam('address', 'the contract address', undefined, types.string, false)

--- a/contracts/test/MarzResources.ts
+++ b/contracts/test/MarzResources.ts
@@ -62,6 +62,11 @@ describe('MarzResources:construction', () => {
     const tokenId = 0
     expect(await resources.claimed(tokenId)).to.eq(0)
   })
+
+  it('should get the proper uri', async function () {
+    const { resources } = await setupContracts()
+    expect(await resources.uri(5)).to.eq('https://api.marzmining.xyz/token/5')
+  })
 })
 
 describe('MarzResources:getResources', () => {


### PR DESCRIPTION
Opensea is apparently not smart enough to automatically replace the {id}
sentinel with the tokenId, and so they are failing to fetch data for any
of the resource card tokens